### PR TITLE
Proposed solution for #176. Hides 'advanced search' menu when showing results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ technical and privacy challenges here, and we seek to identify those early.
 
 Set up a virtual environment:
 
+To install virtualenv:
+```
+pip install virtualenv 
+```
+
 ```
 virtualenv venv --python=python3
 source venv/bin/activate
@@ -186,6 +191,20 @@ In the openledger directory, run:
 
 ```
 eb init
+```
+
+Create the elasticsearch index named openledger (you can change its name in settins/openledger.py) 
+```
+curl -XPUT 'localhost:9200/openledger?pretty' -H 'Content-Type: application/json' -d'
+{
+    "settings" : {
+        "index" : {
+            "number_of_shards" : 3, 
+            "number_of_replicas" : 2 
+        }
+    }
+}
+'
 ```
 
 When you are ready to deploy, *run the tests first*.

--- a/imageledger/jinja2/includes/search-form-abbr.html
+++ b/imageledger/jinja2/includes/search-form-abbr.html
@@ -17,7 +17,7 @@
           </div>
       </div>
       <p>
-      	<a href="{{ url_with_form('index', form or [], args=[], kwargs={'advanced': true}) }}">Advanced search.</a>
+      	<a href="{{ url_with_form('index', form or [], args=[], kwargs={'advanced': True}) }}">Advanced search.</a>
       </p>
 
     </div>

--- a/imageledger/jinja2/includes/search-form-abbr.html
+++ b/imageledger/jinja2/includes/search-form-abbr.html
@@ -1,0 +1,27 @@
+<form method="GET" action="{{ endpoint }}" class="search-form"
+      onSubmit="openledger.form.resetSearchOnSubmit(this)">
+
+  <div class="row align-center">
+    <div class="column">
+      <div class="row">
+        <img class="logo-black" src="{{ static('images/cc.svg') }}" alt="CC" />
+          <div class="column">
+            <img src="{{ static('images/title-search.svg') }}" alt="Search" width="200"/>
+            <div class="search-field-container">
+              <i class="fi-magnifying-glass"></i>
+              {{ form.search }}
+              {{ form.page }}
+              <input type="submit" class="button" value="GO" />
+            </div>
+
+          </div>
+      </div>
+      <p>
+      	<a href="{{ url_with_form('index', form or [], args=[], kwargs={'advanced': true}) }}">Advanced search.</a>
+      </p>
+
+    </div>
+  </div>
+
+
+</form>

--- a/imageledger/jinja2/results.html
+++ b/imageledger/jinja2/results.html
@@ -8,7 +8,11 @@
 
 {% with %}
   {% set endpoint = '' %}
-  {% include "includes/search-form.html" %}
+  {% if results.items|length == 0 or request.GET.get('advanced', '') != '' %}
+  	{% include "includes/search-form.html" %}
+  {% else %}
+  	{% include "includes/search-form-abbr.html" %}
+  {% endif %}
 {% endwith %}
 
 

--- a/imageledger/jinja2/results.html
+++ b/imageledger/jinja2/results.html
@@ -8,7 +8,7 @@
 
 {% with %}
   {% set endpoint = '' %}
-  {% if results.items|length == 0 or request.GET.get('advanced', '') != '' %}
+  {% if results.items|length == 0 or request.GET.get('advanced') != None %}
   	{% include "includes/search-form.html" %}
   {% else %}
   	{% include "includes/search-form-abbr.html" %}

--- a/imageledger/tests/test_search.py
+++ b/imageledger/tests/test_search.py
@@ -97,20 +97,24 @@ class TestSearch(TestCase):
         """It should be possible to load the search view"""
         resp = self.client.get(self.url)
         assert 200 == resp.status_code
+    
+    def test_search_advanced(self):
+        """It should be possible to specify the advanced search URL parameter and get the advanced search form"""
+        resp = self.client.get(self.url, {'search': 'nothing', 'advanced': 'true'})
+        assert select_node(resp, '.search-filters') is not None
 
     def test_search_no_results(self):
-        """It should be possible to get a no-results page"""
+        """It should be possible to get a no-results page and to show the advanced search form"""
         resp = self.client.get(self.url, {'search': 'nothing', 'search_fields': 'title'})
-        p = select_node(resp, '.t-no-results')
-        assert p is not None
+        assert select_node(resp, '.t-no-results') is not None and select_node(resp, '.search-filters') is not None
 
     def test_search_results(self):
-        """If indexed, a single result should be returned from the search engine"""
+        """If indexed, a single result should be returned from the search engine, the advanced search form should be hidden"""
         self._index_img(self.img1)
         resp = self.client.get(self.url, {'search': 'greyhounds', 'search_fields': 'title'})
         p = select_nodes(resp, '.t-image-result')
         self.assertEquals(1, len(p))
-        assert select_node(resp, '.t-no-results') is None
+        assert select_node(resp, '.t-no-results') is None and select_node(resp, '.search-filters') is None
 
 
     def test_search_filter_creator(self):


### PR DESCRIPTION
I think the best way to reduce the space above search results is to hide all the search options and create an 'advanced search' link.

The 'advanced search' link takes the current search parameters and just adds an "advanced=t" parameter to the URL which then is read by the view so it knows which search form to include: the full search or the abbreviated one.

