### PR TITLE
[FIX] Outdated reference version of Elasticsearch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,16 @@ GRANT
 
 ### Elasticsearch
 
-The app uses ES 2.4, which is the latest version supported by AWS. *You must use Elasticsearch 2.4 or the application will not work.*
+*You must have to use Elasticsearch 5.3 or the application will not work.*
 
 On macOS:
 
 ```
-brew install elasticsearch24
+brew install elasticsearch53
 ```
 
 Debian-based:
-https://www.elastic.co/guide/en/elasticsearch/reference/2.4/setup-repositories.html
+https://www.elastic.co/guide/en/elasticsearch/reference/5.3/deb.html
 
 ## Testing a development installation
 


### PR DESCRIPTION
### Description

Updating outdated version of Elasticsearch at core instructions of building software.

### Note

The version update of `brew` is something I am unable to verify because I am not in Macintosh architecture. I need someone help who can confirm that step.